### PR TITLE
Make Sea Turtle a beginner-friendly self-study lab with research mode

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -30,6 +30,17 @@ and ES-module JavaScript.
   CSV/JSON export of the parametric study.
 - Inline field help and an assumptions panel document the first-order model.
 
+### Physics model (Sea Turtle)
+
+No-lift planar ballistic entry in `(h, V, γ)`:
+
+- drag only (`L/D = 0`), exponential atmosphere, inverse-square gravity
+- midpoint (RK2) integration with a variable time step
+- peak G from heat-shield aero; chute opening shock reported separately
+- Allen–Eggers closed-form peak-G teaching check
+- Sutton–Graves-style stagnation heat-flux estimate
+- `SKIP` status when a shallow/high-energy trajectory lofts instead of capturing
+
 ## Run locally
 
 Because it uses ES modules, open it through a local server (not `file://`):

--- a/web/README.md
+++ b/web/README.md
@@ -15,11 +15,20 @@ web/
 └── js/
     ├── sim.js      # physics engine (ported from the Python reference)
     ├── plot.js     # dependency-free canvas line charts
-    └── app.js      # UI wiring, input validation, rendering
+    ├── learn.js    # presets, glossary, study modules, run narratives
+    └── app.js      # UI wiring, Learn/Research modes, export
 ```
 
 Zero build step and zero third-party runtime dependencies — plain HTML, CSS,
 and ES-module JavaScript.
+
+### Learning & research UX
+
+- **Learn mode** — guided presets, concept glossary, self-study modules, and a
+  plain-language “what just happened” narrative after each run.
+- **Research mode** — custom shield/chute diameter sweeps, targeting knobs, and
+  CSV/JSON export of the parametric study.
+- Inline field help and an assumptions panel document the first-order model.
 
 ## Run locally
 

--- a/web/index.html
+++ b/web/index.html
@@ -168,10 +168,11 @@
             <div>
               <h2 class="section-title">Re-Entry Predictor <span class="alias">(Sea Turtle)</span></h2>
               <p class="section-sub">
-                Estimate deceleration, heating, and survivability for an entry from
-                the Kármán line. A 2-DOF point-mass model with an exponential
-                atmosphere and Sutton–Graves-style stagnation heating. Everything is
-                computed live in your browser.
+                Estimate deceleration, heating, and survivability for a
+                <strong>no-lift ballistic</strong> entry. Planar 2-DOF dynamics in
+                (h,&nbsp;V,&nbsp;γ) with exponential atmosphere, inverse-square
+                gravity, and Sutton–Graves-style stagnation heating — computed live
+                in your browser.
               </p>
             </div>
             <div class="mode-switch" role="group" aria-label="Experience mode">

--- a/web/index.html
+++ b/web/index.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="styles.css" />
     <script type="module" src="js/app.js"></script>
   </head>
-  <body>
+  <body data-mode="learn">
     <header class="site-header">
       <div class="wrap header-inner">
         <a class="brand" href="#top">
@@ -32,6 +32,7 @@
         </a>
         <nav class="nav">
           <a href="#focus">Focus areas</a>
+          <a href="#learn">Learn</a>
           <a href="#tool">Re-Entry Predictor</a>
           <a href="#philosophy">Philosophy</a>
         </nav>
@@ -50,11 +51,13 @@
           <p class="lede">
             STRIDE bridges propulsion, aerodynamics, structures, and mission
             design into a unified environment for exploring how engine choices
-            interact with vehicle performance across ascent, cruise, and entry.
+            interact with vehicle performance across ascent, cruise, and entry —
+            built as a self-study lab for students and a transparent first-order
+            workbench for researchers.
           </p>
           <div class="cta-row">
             <a class="btn btn-primary" href="#tool">Launch the Re-Entry Predictor</a>
-            <a class="btn btn-ghost" href="#focus">Explore focus areas</a>
+            <a class="btn btn-ghost" href="#learn">Start the learning path</a>
           </div>
           <p class="badge-row">
             <span class="pill">Physics-informed first-order models</span>
@@ -92,7 +95,7 @@
                 architectures — with a focus on mode-transition logic and
                 operating envelopes.
               </p>
-              <span class="card-link muted-link">On the roadmap</span>
+              <a class="card-link" href="https://github.com/pzrendon/STRIDE#marlin-web-prototype">Prototype in repo →</a>
             </article>
             <article class="card">
               <div class="card-tag">Dolphin</div>
@@ -108,16 +111,87 @@
         </div>
       </section>
 
-      <!-- TOOL -->
-      <section id="tool" class="section section-alt">
+      <!-- LEARN -->
+      <section id="learn" class="section section-alt">
         <div class="wrap">
-          <h2 class="section-title">Re-Entry Predictor <span class="alias">(Sea Turtle)</span></h2>
+          <h2 class="section-title">Learn re-entry physics</h2>
           <p class="section-sub">
-            Estimate deceleration, heating, and survivability for an entry from
-            the Kármán line. A 2-DOF point-mass model with an exponential
-            atmosphere and Sutton–Graves-style stagnation heating. Everything is
-            computed live in your browser.
+            Sea Turtle is a self-study lab: run a transparent 2-DOF entry model,
+            read what the numbers mean, then push into researcher sweeps and CSV
+            export when you are ready.
           </p>
+
+          <div class="learn-grid">
+            <div class="panel learn-panel">
+              <h3 class="panel-title">How to use this tool</h3>
+              <ol class="howto">
+                <li>Pick a <strong>mission preset</strong> below (or keep the LEO default).</li>
+                <li>Stay in <strong>Learn</strong> mode first — fewer knobs, guided story after each run.</li>
+                <li>Change <em>one</em> input at a time and re-run. Watch Max G, Heat, and β.</li>
+                <li>Open glossary terms when a symbol or limit is unfamiliar.</li>
+                <li>Switch to <strong>Research</strong> for custom diameter sweeps and data export.</li>
+              </ol>
+              <p class="panel-note">
+                Nothing leaves your browser. Results are conceptual — not for
+                flight certification.
+              </p>
+            </div>
+
+            <div class="panel learn-panel">
+              <h3 class="panel-title">Self-study modules</h3>
+              <div id="study-modules" class="modules"></div>
+            </div>
+          </div>
+
+          <div class="panel glossary-panel">
+            <div class="glossary-head">
+              <h3 class="panel-title">Concept glossary</h3>
+              <p class="panel-note">
+                High-speed aero, thermo, and entry ideas used by the predictor.
+                Expand any term.
+              </p>
+            </div>
+            <div id="glossary" class="glossary"></div>
+          </div>
+
+          <details class="assumptions">
+            <summary>Model assumptions &amp; limits (read before trusting a number)</summary>
+            <ul id="assumptions-list" class="check"></ul>
+          </details>
+        </div>
+      </section>
+
+      <!-- TOOL -->
+      <section id="tool" class="section">
+        <div class="wrap">
+          <div class="tool-intro">
+            <div>
+              <h2 class="section-title">Re-Entry Predictor <span class="alias">(Sea Turtle)</span></h2>
+              <p class="section-sub">
+                Estimate deceleration, heating, and survivability for an entry from
+                the Kármán line. A 2-DOF point-mass model with an exponential
+                atmosphere and Sutton–Graves-style stagnation heating. Everything is
+                computed live in your browser.
+              </p>
+            </div>
+            <div class="mode-switch" role="group" aria-label="Experience mode">
+              <button type="button" class="mode-btn is-active" data-mode="learn" id="mode-learn">
+                Learn
+              </button>
+              <button type="button" class="mode-btn" data-mode="research" id="mode-research">
+                Research
+              </button>
+            </div>
+          </div>
+
+          <div class="preset-block">
+            <h3 class="preset-heading">Mission presets</h3>
+            <p class="panel-note">
+              Start from a known story, then tweak. Active preset highlights below.
+            </p>
+            <div id="presets" class="presets" role="list"></div>
+            <p id="preset-teach" class="preset-teach" aria-live="polite"></p>
+          </div>
 
           <div class="tool-grid">
             <!-- INPUTS -->
@@ -127,15 +201,19 @@
               <fieldset>
                 <legend>Vehicle &amp; entry state</legend>
                 <label>Payload mass (kg)
+                  <span class="field-help" data-help-for="payloadMassKg"></span>
                   <input id="payloadMassKg" type="number" step="0.1" value="24" />
                 </label>
                 <label>Start altitude (km)
+                  <span class="field-help" data-help-for="startAltKm"></span>
                   <input id="startAltKm" type="number" step="1" value="300" />
                 </label>
                 <label>Entry velocity (m/s)
+                  <span class="field-help" data-help-for="startVelMps"></span>
                   <input id="startVelMps" type="number" step="10" value="7650" />
                 </label>
                 <label>Entry angle (deg)
+                  <span class="field-help" data-help-for="entryAngleDeg"></span>
                   <input id="entryAngleDeg" type="number" step="0.05" value="3.75" />
                 </label>
               </fieldset>
@@ -143,15 +221,19 @@
               <fieldset>
                 <legend>Aerodynamics</legend>
                 <label>Shield C<sub>d</sub>
+                  <span class="field-help" data-help-for="shieldCd"></span>
                   <input id="shieldCd" type="number" step="0.05" value="1.5" />
                 </label>
                 <label>Chute C<sub>d</sub>
+                  <span class="field-help" data-help-for="chuteCd"></span>
                   <input id="chuteCd" type="number" step="0.05" value="1.8" />
                 </label>
                 <label>Chute deploy alt (m)
+                  <span class="field-help" data-help-for="chuteDeployAltM"></span>
                   <input id="chuteDeployAltM" type="number" step="100" value="5000" />
                 </label>
-                <label>Shock factor ×
+                <label class="research-only">Shock factor ×
+                  <span class="field-help" data-help-for="shockFactorX"></span>
                   <input id="shockFactorX" type="number" step="0.1" value="1.6" />
                 </label>
               </fieldset>
@@ -159,32 +241,60 @@
               <fieldset>
                 <legend>Thermal protection &amp; target</legend>
                 <label>TPS density (kg/m³)
+                  <span class="field-help" data-help-for="tpsDensity"></span>
                   <input id="tpsDensity" type="number" step="10" value="480" />
                 </label>
                 <label>TPS thickness (m)
+                  <span class="field-help" data-help-for="tpsThickness"></span>
                   <input id="tpsThickness" type="number" step="0.005" value="0.05" />
                 </label>
-                <label>Target latitude (deg)
+                <label class="research-only">Target latitude (deg)
+                  <span class="field-help" data-help-for="targetLat"></span>
                   <input id="targetLat" type="number" step="0.01" value="28.47" />
                 </label>
-                <label>Target longitude (deg)
+                <label class="research-only">Target longitude (deg)
+                  <span class="field-help" data-help-for="targetLon"></span>
                   <input id="targetLon" type="number" step="0.01" value="-80.57" />
                 </label>
+              </fieldset>
+
+              <fieldset class="research-only">
+                <legend>Parametric sweep</legend>
+                <label>Shield diameters (m)
+                  <span class="field-help" data-help-for="testShieldDiams"></span>
+                  <input id="testShieldDiams" type="text" value="0.8, 1.2, 1.8" spellcheck="false" />
+                </label>
+                <label>Chute diameters (m)
+                  <span class="field-help" data-help-for="testChuteDiams"></span>
+                  <input id="testChuteDiams" type="text" value="3.0, 5.0" spellcheck="false" />
+                </label>
+                <p class="panel-note">
+                  Comma-separated. Charts plot the first chute diameter across each shield.
+                  Cap: 12×12 cases per run.
+                </p>
               </fieldset>
 
               <div class="btn-row">
                 <button id="run-btn" type="button" class="btn btn-primary">Run simulation</button>
                 <button id="reset-btn" type="button" class="btn btn-ghost">Reset</button>
+                <button id="export-csv-btn" type="button" class="btn btn-ghost research-only">Export CSV</button>
+                <button id="export-json-btn" type="button" class="btn btn-ghost research-only">Export JSON</button>
               </div>
               <p id="run-status" class="run-status" aria-live="polite"></p>
             </form>
 
             <!-- OUTPUTS -->
             <div class="panel outputs">
+              <div id="narrative" class="narrative" aria-live="polite">
+                <h3 class="panel-title">What just happened</h3>
+                <p id="narrative-headline" class="narrative-headline"></p>
+                <div id="narrative-body" class="narrative-body"></div>
+                <ul id="narrative-takeaways" class="narrative-takeaways"></ul>
+              </div>
+
               <h3 class="panel-title">Parametric study</h3>
-              <p class="panel-note">
-                Sweeps heat-shield diameters (0.8 / 1.2 / 1.8 m) × chute
-                diameters (3.0 / 5.0 m) at the configured entry angle.
+              <p class="panel-note" id="sweep-note">
+                Sweeps heat-shield diameters × chute diameters at the configured entry angle.
               </p>
               <div class="table-scroll">
                 <table class="results">
@@ -192,12 +302,14 @@
                     <tr>
                       <th>Shield (m)</th>
                       <th>Chute (m)</th>
-                      <th>β</th>
-                      <th>Space phase</th>
-                      <th>Air phase</th>
-                      <th>Max G</th>
-                      <th>Shock G</th>
-                      <th>Heat</th>
+                      <th title="Ballistic coefficient m/(Cd·A)">β</th>
+                      <th title="Time from start to Kármán line">Space phase</th>
+                      <th title="Time from Kármán line to landing">Air phase</th>
+                      <th title="Peak deceleration">Max G</th>
+                      <th title="Parachute opening shock">Shock G</th>
+                      <th title="Peak stagnation heat flux">Heat</th>
+                      <th title="Altitude of peak G (km)">h@G</th>
+                      <th title="Altitude of peak heat (km)">h@q</th>
                       <th>Status</th>
                     </tr>
                   </thead>
@@ -220,7 +332,7 @@
       </section>
 
       <!-- PHILOSOPHY -->
-      <section id="philosophy" class="section">
+      <section id="philosophy" class="section section-alt">
         <div class="wrap two-col">
           <div>
             <h2 class="section-title">Design philosophy</h2>
@@ -239,9 +351,9 @@
             <h2 class="section-title">Intended use</h2>
             <ul class="check">
               <li>Conceptual vehicle design studies.</li>
+              <li>Self-study for high-speed aero, thermo, and entry.</li>
               <li>Propulsion and mission trade analysis.</li>
               <li>Educational and research projects.</li>
-              <li>Demonstrating system-level aerospace capability.</li>
             </ul>
             <p class="muted">
               Not intended for flight certification or detailed component design.

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -7,6 +7,14 @@
 
 import { DEFAULT_CONFIG, runStudy } from "./sim.js";
 import { drawLineChart } from "./plot.js";
+import {
+  PRESETS,
+  GLOSSARY,
+  FIELD_HELP,
+  MODEL_ASSUMPTIONS,
+  STUDY_MODULES,
+  buildNarrative,
+} from "./learn.js";
 
 // [element id, config key, min, max]
 const FIELDS = [
@@ -24,7 +32,24 @@ const FIELDS = [
   ["shockFactorX", "shockFactorX", 0.5, 5],
 ];
 
+const MAX_SWEEP = 12;
+
 const clamp = (v, min, max) => Math.min(max, Math.max(min, v));
+
+let mode = "learn";
+let activePresetId = "leo-capsule";
+let lastStudy = null;
+let lastCfg = null;
+
+function parseDiameterList(raw, fallback) {
+  const parts = String(raw)
+    .split(/[,;\s]+/)
+    .map((s) => Number.parseFloat(s))
+    .filter((n) => Number.isFinite(n) && n > 0 && n < 100);
+  const unique = [...new Set(parts.map((n) => Math.round(n * 1000) / 1000))];
+  if (!unique.length) return [...fallback];
+  return unique.slice(0, MAX_SWEEP);
+}
 
 function readConfig() {
   const cfg = { ...DEFAULT_CONFIG };
@@ -36,7 +61,37 @@ function readConfig() {
     cfg[key] = val;
     el.value = String(val);
   }
+
+  const shieldEl = document.getElementById("testShieldDiams");
+  const chuteEl = document.getElementById("testChuteDiams");
+  cfg.testShieldDiams = parseDiameterList(
+    shieldEl?.value ?? "",
+    DEFAULT_CONFIG.testShieldDiams,
+  );
+  cfg.testChuteDiams = parseDiameterList(
+    chuteEl?.value ?? "",
+    DEFAULT_CONFIG.testChuteDiams,
+  );
+  if (shieldEl) shieldEl.value = cfg.testShieldDiams.join(", ");
+  if (chuteEl) chuteEl.value = cfg.testChuteDiams.join(", ");
+
   return cfg;
+}
+
+function writeConfig(values) {
+  for (const [id, key] of FIELDS) {
+    const el = document.getElementById(id);
+    if (!el || values[key] == null) continue;
+    el.value = String(values[key]);
+  }
+  if (values.testShieldDiams) {
+    const el = document.getElementById("testShieldDiams");
+    if (el) el.value = values.testShieldDiams.join(", ");
+  }
+  if (values.testChuteDiams) {
+    const el = document.getElementById("testChuteDiams");
+    if (el) el.value = values.testChuteDiams.join(", ");
+  }
 }
 
 function fmtHMS(seconds) {
@@ -61,6 +116,8 @@ function renderTable(rows) {
       r.g.toFixed(1),
       r.shock.toFixed(1),
       r.q.toFixed(1),
+      r.altMaxG != null ? r.altMaxG.toFixed(1) : "—",
+      r.altMaxQ != null ? r.altMaxQ.toFixed(1) : "—",
       r.status,
     ];
     cells.forEach((text, i) => {
@@ -89,18 +146,24 @@ function renderRecommendations(study, cfg) {
   msgs.push(
     `Deorbit burn target: Lat ${cfg.targetLat.toFixed(2)}, Long ${study.deorbitLon.toFixed(4)}.`,
   );
-  msgs.push(
-    `Steepest survivable entry angle (11.9 G limit): ${study.steepestAngle.toFixed(3)}°.`,
-  );
+  if (study.steepestFeasible) {
+    msgs.push(
+      `Steepest survivable entry angle (11.9 G limit): ${study.steepestAngle.toFixed(3)}°.`,
+    );
+  } else {
+    msgs.push(
+      `No angle in the 0.5–10° search stays under 11.9 G for the reference shield/chute (shallow probe ≈ ${Number(study.shallowG).toFixed(1)} G). This no-lift ballistic model is intentionally harsh — compare configurations relatively.`,
+    );
+  }
 
   if (worst.g > 12) {
     msgs.push(
-      `CRITICAL: peak G-load of ${worst.g.toFixed(1)} exceeds the 12 G structural limit. Shallow the entry angle toward ~${study.steepestAngle.toFixed(2)}° or enlarge the heat shield.`,
+      `Peak G-load of ${worst.g.toFixed(1)} exceeds the 12 G teaching limit. Try a larger heat shield, lower entry speed, or study how real vehicles add lift to lengthen the deceleration pulse.`,
     );
   }
   if (worstShock.shock > 12) {
     msgs.push(
-      `DANGER: parachute opening shock (${worstShock.shock.toFixed(1)} G) can snap shroud lines. Increase deployment altitude or use a smaller main chute.`,
+      `Parachute opening shock (${worstShock.shock.toFixed(1)} G) can snap shroud lines. Increase deployment altitude or use a smaller main chute.`,
     );
   }
   if (worst.g <= 12 && worstShock.shock <= 12) {
@@ -111,6 +174,26 @@ function renderRecommendations(study, cfg) {
     const li = document.createElement("li");
     li.textContent = m;
     box.appendChild(li);
+  }
+}
+
+function renderNarrative(study, cfg) {
+  const story = buildNarrative(study, cfg);
+  const headline = document.getElementById("narrative-headline");
+  const body = document.getElementById("narrative-body");
+  const takes = document.getElementById("narrative-takeaways");
+  headline.textContent = story.headline;
+  body.textContent = "";
+  for (const p of story.paragraphs) {
+    const el = document.createElement("p");
+    el.textContent = p;
+    body.appendChild(el);
+  }
+  takes.textContent = "";
+  for (const t of story.takeaways) {
+    const li = document.createElement("li");
+    li.textContent = t;
+    takes.appendChild(li);
   }
 }
 
@@ -129,7 +212,11 @@ function renderCharts(study) {
   });
 }
 
-let lastStudy = null;
+function updateSweepNote(cfg) {
+  const note = document.getElementById("sweep-note");
+  if (!note) return;
+  note.textContent = `Sweeps shield diameters [${cfg.testShieldDiams.join(", ")}] m × chute diameters [${cfg.testChuteDiams.join(", ")}] m at γ = ${cfg.entryAngleDeg}°. Charts use the first chute size.`;
+}
 
 function run() {
   const status = document.getElementById("run-status");
@@ -140,25 +227,238 @@ function run() {
     const cfg = readConfig();
     const study = runStudy(cfg);
     lastStudy = study;
+    lastCfg = cfg;
     renderTable(study.rows);
     renderRecommendations(study, cfg);
+    renderNarrative(study, cfg);
     renderCharts(study);
+    updateSweepNote(cfg);
     const ms = (performance.now() - t0).toFixed(0);
     status.textContent = `Done in ${ms} ms — ${study.rows.length} configurations simulated in your browser.`;
   });
 }
 
+function setMode(next) {
+  mode = next === "research" ? "research" : "learn";
+  document.body.dataset.mode = mode;
+  document.getElementById("mode-learn")?.classList.toggle("is-active", mode === "learn");
+  document.getElementById("mode-research")?.classList.toggle("is-active", mode === "research");
+}
+
+function applyPreset(preset) {
+  activePresetId = preset.id;
+  writeConfig({
+    ...preset.values,
+    testShieldDiams: DEFAULT_CONFIG.testShieldDiams,
+    testChuteDiams: DEFAULT_CONFIG.testChuteDiams,
+  });
+  document.querySelectorAll(".preset-card").forEach((btn) => {
+    btn.classList.toggle("is-active", btn.dataset.presetId === preset.id);
+  });
+  const teach = document.getElementById("preset-teach");
+  if (teach) {
+    teach.textContent = `${preset.blurb} ${preset.teach}`;
+  }
+  run();
+}
+
+function renderPresets() {
+  const root = document.getElementById("presets");
+  if (!root) return;
+  root.textContent = "";
+  for (const preset of PRESETS) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "preset-card";
+    btn.dataset.presetId = preset.id;
+    btn.setAttribute("role", "listitem");
+    if (preset.id === activePresetId) btn.classList.add("is-active");
+
+    const level = document.createElement("span");
+    level.className = "preset-level";
+    level.textContent = preset.level;
+
+    const name = document.createElement("span");
+    name.className = "preset-name";
+    name.textContent = preset.name;
+
+    const blurb = document.createElement("span");
+    blurb.className = "preset-blurb";
+    blurb.textContent = preset.blurb;
+
+    btn.append(level, name, blurb);
+    btn.addEventListener("click", () => applyPreset(preset));
+    root.appendChild(btn);
+  }
+  const active = PRESETS.find((p) => p.id === activePresetId) || PRESETS[0];
+  const teach = document.getElementById("preset-teach");
+  if (teach && active) teach.textContent = `${active.blurb} ${active.teach}`;
+}
+
+function renderGlossary() {
+  const root = document.getElementById("glossary");
+  if (!root) return;
+  root.textContent = "";
+  for (const item of GLOSSARY) {
+    const details = document.createElement("details");
+    details.className = "glossary-item";
+    details.id = `glossary-${item.id}`;
+
+    const summary = document.createElement("summary");
+    const term = document.createElement("span");
+    term.className = "glossary-term";
+    term.textContent = item.term;
+    const short = document.createElement("span");
+    short.className = "glossary-short";
+    short.textContent = item.short;
+    summary.append(term, short);
+
+    const body = document.createElement("p");
+    body.className = "glossary-body";
+    body.textContent = item.body;
+
+    details.append(summary, body);
+    root.appendChild(details);
+  }
+}
+
+function renderModules() {
+  const root = document.getElementById("study-modules");
+  if (!root) return;
+  root.textContent = "";
+  for (const mod of STUDY_MODULES) {
+    const article = document.createElement("article");
+    article.className = "module";
+    const h = document.createElement("h4");
+    h.textContent = mod.title;
+    const ol = document.createElement("ol");
+    for (const step of mod.steps) {
+      const li = document.createElement("li");
+      li.textContent = step;
+      ol.appendChild(li);
+    }
+    article.append(h, ol);
+    root.appendChild(article);
+  }
+}
+
+function renderAssumptions() {
+  const root = document.getElementById("assumptions-list");
+  if (!root) return;
+  root.textContent = "";
+  for (const line of MODEL_ASSUMPTIONS) {
+    const li = document.createElement("li");
+    li.textContent = line;
+    root.appendChild(li);
+  }
+}
+
+function renderFieldHelp() {
+  document.querySelectorAll("[data-help-for]").forEach((el) => {
+    const key = el.getAttribute("data-help-for");
+    const text = FIELD_HELP[key];
+    if (!text) return;
+    el.textContent = text;
+  });
+}
+
+function downloadBlob(filename, mime, text) {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function exportCsv() {
+  if (!lastStudy) return;
+  const header = [
+    "shield_m",
+    "chute_m",
+    "beta_kg_m2",
+    "space_phase_s",
+    "air_phase_s",
+    "max_g",
+    "shock_g",
+    "heat_w_cm2",
+    "alt_max_g_km",
+    "alt_max_q_km",
+    "status",
+  ];
+  const lines = [header.join(",")];
+  for (const r of lastStudy.rows) {
+    lines.push(
+      [
+        r.shield,
+        r.chute,
+        r.beta.toFixed(4),
+        r.t1.toFixed(3),
+        r.t2.toFixed(3),
+        r.g.toFixed(4),
+        r.shock.toFixed(4),
+        r.q.toFixed(4),
+        r.altMaxG?.toFixed(3) ?? "",
+        r.altMaxQ?.toFixed(3) ?? "",
+        r.status,
+      ].join(","),
+    );
+  }
+  downloadBlob("sea-turtle-study.csv", "text/csv;charset=utf-8", lines.join("\n"));
+}
+
+function exportJson() {
+  if (!lastStudy || !lastCfg) return;
+  const payload = {
+    tool: "STRIDE Sea Turtle Re-Entry Predictor",
+    exportedAt: new Date().toISOString(),
+    disclaimer: "Conceptual first-order model. Not for operational use.",
+    config: lastCfg,
+    deorbitLon: lastStudy.deorbitLon,
+    steepestAngle: lastStudy.steepestAngle,
+    steepestFeasible: lastStudy.steepestFeasible,
+    shallowG: lastStudy.shallowG,
+    rows: lastStudy.rows,
+  };
+  downloadBlob(
+    "sea-turtle-study.json",
+    "application/json;charset=utf-8",
+    JSON.stringify(payload, null, 2),
+  );
+}
+
 function init() {
+  document.body.dataset.mode = mode;
+  renderPresets();
+  renderGlossary();
+  renderModules();
+  renderAssumptions();
+  renderFieldHelp();
+
   document.getElementById("run-btn").addEventListener("click", run);
   document.getElementById("reset-btn").addEventListener("click", () => {
-    for (const [id, key] of FIELDS) {
-      const el = document.getElementById(id);
-      if (el) el.value = String(DEFAULT_CONFIG[key]);
-    }
+    const preset = PRESETS.find((p) => p.id === activePresetId) || PRESETS[0];
+    writeConfig({
+      ...DEFAULT_CONFIG,
+      ...(preset?.values ?? {}),
+      testShieldDiams: DEFAULT_CONFIG.testShieldDiams,
+      testChuteDiams: DEFAULT_CONFIG.testChuteDiams,
+    });
+    run();
   });
+  document.getElementById("mode-learn")?.addEventListener("click", () => setMode("learn"));
+  document.getElementById("mode-research")?.addEventListener("click", () => setMode("research"));
+  document.getElementById("export-csv-btn")?.addEventListener("click", exportCsv);
+  document.getElementById("export-json-btn")?.addEventListener("click", exportJson);
+
   window.addEventListener("resize", () => {
     if (lastStudy) renderCharts(lastStudy);
   });
+
   run(); // run once with defaults so the page is populated
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -124,7 +124,9 @@ function renderTable(rows) {
       const td = document.createElement("td");
       td.textContent = text;
       if (i === cells.length - 1) {
-        td.className = r.status === "PASS" ? "pass" : "fail";
+        if (r.status === "PASS") td.className = "pass";
+        else if (r.status === "SKIP") td.className = "skip";
+        else td.className = "fail";
       }
       tr.appendChild(td);
     });
@@ -146,19 +148,29 @@ function renderRecommendations(study, cfg) {
   msgs.push(
     `Deorbit burn target: Lat ${cfg.targetLat.toFixed(2)}, Long ${study.deorbitLon.toFixed(4)}.`,
   );
+  msgs.push(
+    `Allen–Eggers teaching check (V, γ): ≈ ${Number(study.allenEggersG).toFixed(2)} G.`,
+  );
   if (study.steepestFeasible) {
     msgs.push(
       `Steepest survivable entry angle (11.9 G limit): ${study.steepestAngle.toFixed(3)}°.`,
     );
   } else {
     msgs.push(
-      `No angle in the 0.5–10° search stays under 11.9 G for the reference shield/chute (shallow probe ≈ ${Number(study.shallowG).toFixed(1)} G). This no-lift ballistic model is intentionally harsh — compare configurations relatively.`,
+      `No angle in the search stays under 11.9 G for the reference shield/chute (shallow probe ≈ ${Number(study.shallowG).toFixed(1)} G).`,
+    );
+  }
+
+  const skips = study.rows.filter((r) => r.status === "SKIP");
+  if (skips.length) {
+    msgs.push(
+      `${skips.length} configuration(s) SKIPPED (lofted). Steepen the entry angle or reduce entry speed to capture.`,
     );
   }
 
   if (worst.g > 12) {
     msgs.push(
-      `Peak G-load of ${worst.g.toFixed(1)} exceeds the 12 G teaching limit. Try a larger heat shield, lower entry speed, or study how real vehicles add lift to lengthen the deceleration pulse.`,
+      `Peak ballistic G-load of ${worst.g.toFixed(1)} exceeds the 12 G teaching limit. Shallow the entry angle (Allen–Eggers ∝ sin|γ|) or lower entry speed.`,
     );
   }
   if (worstShock.shock > 12) {
@@ -166,7 +178,10 @@ function renderRecommendations(study, cfg) {
       `Parachute opening shock (${worstShock.shock.toFixed(1)} G) can snap shroud lines. Increase deployment altitude or use a smaller main chute.`,
     );
   }
-  if (worst.g <= 12 && worstShock.shock <= 12) {
+  if (
+    study.rows.every((r) => r.status === "PASS") &&
+    study.rows.length > 0
+  ) {
     msgs.push("All tested configurations are within structural limits.");
   }
 
@@ -422,6 +437,7 @@ function exportJson() {
     steepestAngle: lastStudy.steepestAngle,
     steepestFeasible: lastStudy.steepestFeasible,
     shallowG: lastStudy.shallowG,
+    allenEggersG: lastStudy.allenEggersG,
     rows: lastStudy.rows,
   };
   downloadBlob(

--- a/web/js/learn.js
+++ b/web/js/learn.js
@@ -10,9 +10,9 @@ export const PRESETS = Object.freeze([
     name: "LEO capsule (default)",
     level: "beginner",
     blurb:
-      "A small capsule returning from low Earth orbit toward Florida. Good first run — read the story panel even if Status shows FAIL.",
+      "A small capsule returning from low Earth orbit toward Florida. A clean first run of the no-lift ballistic model.",
     teach:
-      "This ballistic (no-lift) model often exceeds the 12 G teaching screen. Focus on how β, Heat, and Shock change across shield sizes.",
+      "Peak G is set mostly by entry speed and γ (Allen–Eggers). Shield size mainly changes heating and chute shock — compare the table columns.",
     values: {
       payloadMassKg: 24,
       startAltKm: 300,
@@ -34,7 +34,8 @@ export const PRESETS = Object.freeze([
     level: "intermediate",
     blurb:
       "Same vehicle, steeper flight-path angle. Peak deceleration rises quickly — a classic survivability trade.",
-    teach: "Compare Max G and Heat against the default. Steeper γ shortens the air phase but spikes loads.",
+    teach:
+      "Compare Max G and Heat against the default. Steeper γ shortens the air phase but spikes loads; Allen–Eggers scales with sin|γ|.",
     values: {
       payloadMassKg: 24,
       startAltKm: 300,
@@ -55,8 +56,9 @@ export const PRESETS = Object.freeze([
     name: "Heavy probe",
     level: "intermediate",
     blurb:
-      "Higher payload mass raises β (ballistic coefficient). The vehicle punches deeper before slowing down.",
-    teach: "Larger β → higher peak heating and G for the same shield. Try enlarging the shield diameter in Research mode.",
+      "Higher payload mass raises β (ballistic coefficient). Peak G barely moves; peak heating and chute shock do.",
+    teach:
+      "For pure ballistic entry, β mainly shifts where heating peaks and how hard the chute opens — not the Allen–Eggers G ceiling.",
     values: {
       payloadMassKg: 120,
       startAltKm: 300,
@@ -77,13 +79,14 @@ export const PRESETS = Object.freeze([
     name: "Higher-energy return",
     level: "advanced",
     blurb:
-      "Faster entry speed (closer to lunar-return class energy, still first-order). Heating scales roughly with V³.",
-    teach: "Sutton–Graves heat flux ∝ √ρ · V³. Small speed increases dominate the thermal story.",
+      "Faster LEO-band entry (~8.2 km/s from 120 km). Heating scales roughly with V³; too-shallow super-circular starts can SKIP.",
+    teach:
+      "Sutton–Graves heat flux ∝ √ρ · V³. If Status shows SKIP, the trajectory lofted — steepen γ or lower speed.",
     values: {
       payloadMassKg: 40,
-      startAltKm: 400,
-      startVelMps: 9500,
-      entryAngleDeg: 4.2,
+      startAltKm: 120,
+      startVelMps: 8200,
+      entryAngleDeg: 5.0,
       targetLat: 28.47,
       targetLon: -80.57,
       shieldCd: 1.5,
@@ -102,55 +105,67 @@ export const GLOSSARY = Object.freeze([
     id: "karman",
     term: "Kármán line",
     short: "Conventionally ~100 km — where “space” begins for this model.",
-    body: "Sea Turtle treats altitudes above 100 km as essentially vacuum (negligible density). The “space phase” clock runs until the vehicle crosses this line; the “air phase” is everything below it.",
+    body: "Sea Turtle uses a continuous exponential atmosphere, but the “space phase” clock still runs until the vehicle crosses 100 km; the “air phase” is everything below it.",
   },
   {
     id: "gamma",
     term: "Entry flight-path angle (γ)",
     short: "How steeply the velocity vector points into the atmosphere.",
-    body: "Small γ (shallow) stretches the deceleration over more atmosphere — lower peak G, longer heat pulse. Large γ (steep) is a short, violent brake. Too steep and structural G limits fail; too shallow and you may skip or overshoot the target corridor.",
+    body: "The UI asks for degrees below the local horizon (positive). Internally γ is negative for descent. Small |γ| (shallow) lowers the Allen–Eggers peak-G estimate but can loft or skip if energy is high; large |γ| (steep) is a short, violent brake.",
   },
   {
     id: "beta",
     term: "Ballistic coefficient (β)",
     short: "β = m / (Cd · A) — how hard the vehicle is to slow with drag.",
-    body: "High β vehicles (heavy, small area, low Cd) reach denser air before slowing, raising peak heating and often peak G. Enlarging the heat shield lowers β. Units here are kg/m².",
+    body: "High β vehicles reach denser air before slowing, raising peak heating and often chute shock. For pure no-lift ballistic entry, peak G is largely set by V and γ (Allen–Eggers), while β mainly moves the altitude of peak heating.",
+  },
+  {
+    id: "allen",
+    term: "Allen–Eggers peak G",
+    short: "Closed-form ballistic estimate: a_max ≈ V² sin|γ| / (2 e H).",
+    body: "A classic exponential-atmosphere result for constant-γ ballistic entry. Sea Turtle’s numerical integrator lets γ steepen as the vehicle slows, so peak G can exceed this estimate — especially at shallow angles. Use it as a teaching check, not a certification number.",
   },
   {
     id: "gload",
     term: "Deceleration (G-load)",
-    short: "Drag acceleration expressed in multiples of Earth gravity.",
-    body: "Peak G is a structural and crew/payload limit. This tool flags configurations above ~12 G as FAIL for the parametric study. Opening-shock G at parachute deploy is a separate spike that can snap lines. Because Sea Turtle is ballistic (no lift), many LEO-like cases fail the screen — use FAIL as a prompt to compare trades, not as a flight prediction.",
+    short: "Shield drag acceleration in multiples of Earth gravity.",
+    body: "Max G is recorded from heat-shield aero only. Opening-shock G at parachute deploy is reported separately. Configurations above ~12 G (or shock) are flagged FAIL for the parametric study.",
   },
   {
     id: "heatflux",
     term: "Stagnation heat flux",
     short: "Estimated convective heating at the nose/shield stagnation point.",
-    body: "Sea Turtle uses a Sutton–Graves-style estimate: q̇ ∝ √(ρ / R_n) · V³. It is a first-order trend tool, not a TPS sizing code. Peak flux (W/cm²) drives material and thickness trades with density.",
+    body: "Sea Turtle uses a Sutton–Graves-style estimate: q̇ ∝ √(ρ / R_n) · V³. It is a first-order trend tool, not a TPS sizing code. Peak flux (W/cm²) falls as shield diameter (nose radius) grows.",
   },
   {
     id: "tps",
     term: "Thermal protection system (TPS)",
     short: "The heat shield mass is area × thickness × density.",
-    body: "TPS mass is added to payload mass before β is computed. Thicker or denser shields protect more but raise mass — which can raise β unless area grows too. Real TPS also ablates and conducts; this model only accounts for inert mass.",
+    body: "TPS mass is added to payload mass before β is computed. Thicker or denser shields protect more but raise mass. Real TPS also ablates and conducts; this model only accounts for inert mass.",
   },
   {
     id: "atmosphere",
     term: "Exponential atmosphere",
-    short: "ρ = ρ₀ · exp(−h / H) below the Kármán line.",
-    body: "With ρ₀ = 1.225 kg/m³ and scale height H ≈ 8.5 km, density grows rapidly as altitude falls. That is why most deceleration and heating concentrate in a relatively thin band of the lower atmosphere.",
+    short: "ρ = ρ₀ · exp(−h / H) with H ≈ 8.5 km.",
+    body: "Density grows rapidly as altitude falls. That is why most deceleration and heating concentrate in a relatively thin band of the atmosphere. Gravity uses an inverse-square law on a spherical Earth.",
   },
   {
     id: "drag",
-    term: "2-DOF point-mass drag model",
-    short: "Planar motion with drag opposing velocity; gravity on the vertical axis.",
-    body: "The integrator steps altitude and velocity components with a variable time step (coarse in space, fine in atmosphere). Lift, Coriolis detail, and shape-dependent aerodynamics are omitted — transparency over fidelity.",
+    term: "No-lift 2-DOF ballistic model",
+    short: "Planar (h, V, γ) dynamics with drag only — L/D = 0.",
+    body: "Governing rates: dh/dt = V sin γ, dV/dt = −D/m − g sin γ, dγ/dt = cos γ · (V/r − g/V). No lift, bank, or guidance. Midpoint (RK2) integration with a variable time step.",
   },
   {
     id: "chute",
     term: "Parachute deploy & opening shock",
     short: "Below deploy altitude, Cd and area switch to the chute.",
-    body: "Opening shock estimates dynamic pressure × chute area × Cd × a shock factor, divided by weight. Deploy higher to open in thinner air; a smaller chute reduces shock but raises terminal speed.",
+    body: "Opening shock estimates dynamic pressure × chute area × Cd × a shock factor, divided by weight, captured on the ballistic state just before chute aero is applied. Deploy higher to open in thinner air; a smaller chute reduces shock but raises terminal speed.",
+  },
+  {
+    id: "skip",
+    term: "Skip / loft (SKIP status)",
+    short: "Trajectory climbs away instead of capturing into the atmosphere.",
+    body: "At super-circular energy with a shallow γ, centrifugal terms can loft the vehicle. Sea Turtle aborts those runs as SKIP. Steepen the entry angle or reduce speed to capture.",
   },
   {
     id: "deorbit",
@@ -164,8 +179,10 @@ export const GLOSSARY = Object.freeze([
 export const FIELD_HELP = Object.freeze({
   payloadMassKg: "Dry payload mass before adding heat-shield TPS mass.",
   startAltKm: "Initial geodetic altitude. Typical LEO returns start near 100–400 km.",
-  startVelMps: "Inertial-ish entry speed magnitude. LEO ≈ 7.5–7.8 km/s; faster ⇒ much more heat.",
-  entryAngleDeg: "Flight-path angle below local horizontal. ~3–5° is a common capsule corridor start.",
+  startVelMps:
+    "Inertial-ish entry speed. LEO ≈ 7.5–7.8 km/s; faster raises heat (~V³) and can SKIP if too shallow.",
+  entryAngleDeg:
+    "Degrees below local horizontal. ~3–5° is a common capsule start; steeper raises peak G (~sin|γ|).",
   targetLat: "Landing-site latitude used for ground-track / deorbit longitude targeting.",
   targetLon: "Landing-site longitude (deg). Positive east.",
   shieldCd: "Heat-shield drag coefficient while ballistic (pre-chute).",
@@ -179,13 +196,15 @@ export const FIELD_HELP = Object.freeze({
 });
 
 export const MODEL_ASSUMPTIONS = Object.freeze([
-  "Point-mass, planar 2-DOF; no lift, bank, or guidance closed loop.",
-  "Exponential atmosphere below 100 km; near-vacuum above.",
+  "No-lift planar 2-DOF in (h, V, γ); L/D = 0 — no bank or guidance.",
+  "Exponential atmosphere ρ = ρ₀ exp(−h/H); inverse-square gravity on a spherical Earth.",
   "Constant Cd per phase (shield vs chute); no Mach/Re tables.",
+  "Peak G from shield drag only; chute opening load reported separately as Shock G.",
+  "Allen–Eggers closed form is shown as a teaching check; numerical γ can steepen.",
   "Sutton–Graves-style stagnation flux — trend only, not certified heating.",
   "TPS contributes mass only; no ablation, conduction, or bond-line temperature.",
-  "Earth rotation appears only in a simple longitude correction.",
-  "PASS/FAIL uses a 12 G structural/crew proxy for peak G and chute shock.",
+  "SKIP means the trajectory lofted above the abort altitude (super-circular / shallow).",
+  "PASS/FAIL uses a 12 G proxy for peak ballistic G and chute shock.",
 ]);
 
 /**
@@ -204,39 +223,49 @@ export function buildNarrative(study, cfg) {
 
   const pass = study.rows.filter((r) => r.status === "PASS");
   const fail = study.rows.filter((r) => r.status === "FAIL");
+  const skip = study.rows.filter((r) => r.status === "SKIP");
   const hottest = study.rows.reduce((a, b) => (b.q > a.q ? b : a), study.rows[0]);
   const hardest = study.rows.reduce((a, b) => (b.g > a.g ? b : a), study.rows[0]);
   const softest = study.rows.reduce((a, b) => (b.g < a.g ? b : a), study.rows[0]);
+  const ae = Number(study.allenEggersG);
 
   const paragraphs = [
-    `You entered from ${cfg.startAltKm} km at ${cfg.startVelMps} m/s with γ = ${cfg.entryAngleDeg}°. Below the Kármán line (~100 km), exponential atmosphere density rises fast, so drag — and heating — concentrate in a relatively thin band.`,
-    `Across ${study.rows.length} shield×chute pairs, ballistic coefficient β ranged from ${Math.min(...study.rows.map((r) => r.beta)).toFixed(0)} to ${Math.max(...study.rows.map((r) => r.beta)).toFixed(0)} kg/m². Larger shields lower β. In this no-lift ballistic model, peak G often stays high even as β falls — real capsules use lift and guidance to stretch the pulse.`,
-    `Hardest peak deceleration: ${hardest.g.toFixed(1)} G (${hardest.shield.toFixed(1)} m shield). Softest in this sweep: ${softest.g.toFixed(1)} G. Hottest stagnation flux: ${hottest.q.toFixed(1)} W/cm² on the ${hottest.shield.toFixed(1)} m shield.`,
+    `No-lift ballistic entry from ${cfg.startAltKm} km at ${cfg.startVelMps} m/s with γ = ${cfg.entryAngleDeg}° below the horizon. The integrator marches (h, V, γ) with drag only, exponential atmosphere, and inverse-square gravity.`,
+    `Allen–Eggers teaching check for these V, γ: ≈ ${ae.toFixed(1)} G. Numerical peaks in this sweep range ${softest.g.toFixed(1)}–${hardest.g.toFixed(1)} G (γ can steepen as the vehicle slows, so the number can exceed the closed form).`,
+    `Across ${study.rows.length} shield×chute pairs, β ranged from ${Math.min(...study.rows.map((r) => r.beta)).toFixed(0)} to ${Math.max(...study.rows.map((r) => r.beta)).toFixed(0)} kg/m². Larger shields mainly cut peak heat flux (hottest here: ${hottest.q.toFixed(1)} W/cm² on the ${hottest.shield.toFixed(1)} m shield) and change chute shock.`,
   ];
 
-  if (hardest.altMaxG != null) {
+  if (hardest.altMaxG != null && hardest.g > 0.05) {
     paragraphs.push(
-      `Peak G for the hardest case sits near ~${hardest.altMaxG.toFixed(0)} km altitude — where density and leftover speed still combine before the vehicle has fully bled energy.`,
+      `Peak ballistic G sits near ~${hardest.altMaxG.toFixed(0)} km for the hardest case — where density and leftover speed still combine before energy is fully bled.`,
+    );
+  }
+
+  if (skip.length) {
+    paragraphs.push(
+      `${skip.length} run(s) lofted and aborted as SKIP. Steepen γ or reduce entry speed to capture into the atmosphere.`,
     );
   }
 
   const corridorNote = study.steepestFeasible
-    ? `Steepest angle under the ≈11.9 G search: ${study.steepestAngle.toFixed(2)}°.`
-    : `Even a very shallow γ (~0.5°) still peaks near ${Number(study.shallowG).toFixed(1)} G in this ballistic model — the 12 G PASS flag is a teaching screen, not a claim that lift-assisted entry is impossible.`;
+    ? `Steepest angle under the ≈11.9 G search (reference shield/chute): ${study.steepestAngle.toFixed(2)}°.`
+    : `No feasible ≤11.9 G corridor found near the shallow probe (≈ ${Number(study.shallowG).toFixed(1)} G).`;
 
   const takeaways = [
-    `${pass.length} of ${study.rows.length} configurations PASS the 12 G peak / chute-shock screen; ${fail.length} FAIL.`,
+    `${pass.length} PASS · ${fail.length} FAIL · ${skip.length} SKIP (12 G peak / chute-shock screen).`,
     corridorNote,
     `Suggested deorbit-burn longitude for Lat ${cfg.targetLat.toFixed(2)}° / Lon ${cfg.targetLon.toFixed(2)}°: ${study.deorbitLon.toFixed(2)}°.`,
-    `Learning tip: change one knob (γ, mass, velocity, or shield size), re-run, and compare Heat and Max G — relative trades matter more than the absolute PASS flag here.`,
+    `Learning tip: change γ to move Max G; change shield diameter to move Heat and Shock — that split is the heart of ballistic entry.`,
   ];
 
   let headline;
-  if (fail.length === 0) {
+  if (skip.length && pass.length === 0 && fail.length === 0) {
+    headline = "All cases skipped — the trajectory lofted instead of capturing.";
+  } else if (fail.length === 0 && skip.length === 0) {
     headline = "All tested configurations stay within the 12 G proxy limits.";
   } else if (pass.length === 0) {
     headline =
-      "All cases exceed the 12 G teaching screen — use relative trades (Heat, β, shock) to learn the physics.";
+      "No PASS in this sweep — shallow γ to cut Max G, or resize the chute to cut opening shock.";
   } else {
     headline = "Mixed results: some shield/chute pairs survive the G screen, others do not.";
   }
@@ -250,31 +279,31 @@ export const STUDY_MODULES = Object.freeze([
     title: "Module 1 — Energy and the atmosphere",
     steps: [
       "Run the LEO capsule preset. Note space-phase vs air-phase times.",
-      "Open the glossary entry for exponential atmosphere.",
-      "Ask: why do both G and heat flux stay near zero until well below 100 km?",
+      "Open the glossary entries for exponential atmosphere and Allen–Eggers.",
+      "Ask: why do G and heat flux stay near zero until well below 100 km?",
     ],
   },
   {
     title: "Module 2 — Ballistic coefficient trades",
     steps: [
-      "Compare the default table rows: how does β fall as shield diameter rises?",
-      "Load Heavy probe. What happens to Max G and Heat at the same γ?",
+      "Compare default table rows: β falls as shield diameter rises — what happens to Heat?",
+      "Load Heavy probe. Does Max G move much? Does Heat?",
       "In Research mode, add a 2.4 m shield diameter to the sweep.",
     ],
   },
   {
     title: "Module 3 — Entry angle corridor",
     steps: [
-      "Run Steep ballistic entry. Compare Max G and Heat to the LEO default.",
-      "Read the engineer notes: this no-lift model may report no feasible 12 G corridor.",
-      "Relate γ to pulse shape: steeper still tends to be sharper; real capsules add lift to stretch the pulse.",
+      "Run Steep ballistic entry. Compare Max G to the Allen–Eggers check in the story panel.",
+      "Use the reported steepest survivable angle from the engineer notes.",
+      "Relate γ to pulse shape: steeper → higher peak G (~sin|γ|).",
     ],
   },
   {
     title: "Module 4 — Heating scales with V³",
     steps: [
       "Run Higher-energy return. Compare peak heat flux to the LEO case.",
-      "Read the Sutton–Graves glossary note.",
+      "If you see SKIP, steepen γ — that is capture physics, not a bug.",
       "Export CSV (Research mode) and plot Heat vs shield diameter offline.",
     ],
   },

--- a/web/js/learn.js
+++ b/web/js/learn.js
@@ -1,0 +1,281 @@
+/*
+ * Sea Turtle learning content — presets, glossary, and post-run narratives.
+ * Kept as plain data + pure functions so the UI can render with textContent.
+ */
+
+/** Beginner-friendly mission presets. Values feed DEFAULT_CONFIG-compatible keys. */
+export const PRESETS = Object.freeze([
+  {
+    id: "leo-capsule",
+    name: "LEO capsule (default)",
+    level: "beginner",
+    blurb:
+      "A small capsule returning from low Earth orbit toward Florida. Good first run — read the story panel even if Status shows FAIL.",
+    teach:
+      "This ballistic (no-lift) model often exceeds the 12 G teaching screen. Focus on how β, Heat, and Shock change across shield sizes.",
+    values: {
+      payloadMassKg: 24,
+      startAltKm: 300,
+      startVelMps: 7650,
+      entryAngleDeg: 3.75,
+      targetLat: 28.47,
+      targetLon: -80.57,
+      shieldCd: 1.5,
+      chuteCd: 1.8,
+      chuteDeployAltM: 5000,
+      tpsDensity: 480,
+      tpsThickness: 0.05,
+      shockFactorX: 1.6,
+    },
+  },
+  {
+    id: "steep-ballistic",
+    name: "Steep ballistic entry",
+    level: "intermediate",
+    blurb:
+      "Same vehicle, steeper flight-path angle. Peak deceleration rises quickly — a classic survivability trade.",
+    teach: "Compare Max G and Heat against the default. Steeper γ shortens the air phase but spikes loads.",
+    values: {
+      payloadMassKg: 24,
+      startAltKm: 300,
+      startVelMps: 7650,
+      entryAngleDeg: 6.5,
+      targetLat: 28.47,
+      targetLon: -80.57,
+      shieldCd: 1.5,
+      chuteCd: 1.8,
+      chuteDeployAltM: 5000,
+      tpsDensity: 480,
+      tpsThickness: 0.05,
+      shockFactorX: 1.6,
+    },
+  },
+  {
+    id: "heavy-probe",
+    name: "Heavy probe",
+    level: "intermediate",
+    blurb:
+      "Higher payload mass raises β (ballistic coefficient). The vehicle punches deeper before slowing down.",
+    teach: "Larger β → higher peak heating and G for the same shield. Try enlarging the shield diameter in Research mode.",
+    values: {
+      payloadMassKg: 120,
+      startAltKm: 300,
+      startVelMps: 7650,
+      entryAngleDeg: 3.75,
+      targetLat: 28.47,
+      targetLon: -80.57,
+      shieldCd: 1.5,
+      chuteCd: 1.8,
+      chuteDeployAltM: 6000,
+      tpsDensity: 480,
+      tpsThickness: 0.08,
+      shockFactorX: 1.6,
+    },
+  },
+  {
+    id: "high-energy",
+    name: "Higher-energy return",
+    level: "advanced",
+    blurb:
+      "Faster entry speed (closer to lunar-return class energy, still first-order). Heating scales roughly with V³.",
+    teach: "Sutton–Graves heat flux ∝ √ρ · V³. Small speed increases dominate the thermal story.",
+    values: {
+      payloadMassKg: 40,
+      startAltKm: 400,
+      startVelMps: 9500,
+      entryAngleDeg: 4.2,
+      targetLat: 28.47,
+      targetLon: -80.57,
+      shieldCd: 1.5,
+      chuteCd: 1.8,
+      chuteDeployAltM: 8000,
+      tpsDensity: 480,
+      tpsThickness: 0.1,
+      shockFactorX: 1.8,
+    },
+  },
+]);
+
+/** Concept glossary for the Learn panel and inline field help. */
+export const GLOSSARY = Object.freeze([
+  {
+    id: "karman",
+    term: "Kármán line",
+    short: "Conventionally ~100 km — where “space” begins for this model.",
+    body: "Sea Turtle treats altitudes above 100 km as essentially vacuum (negligible density). The “space phase” clock runs until the vehicle crosses this line; the “air phase” is everything below it.",
+  },
+  {
+    id: "gamma",
+    term: "Entry flight-path angle (γ)",
+    short: "How steeply the velocity vector points into the atmosphere.",
+    body: "Small γ (shallow) stretches the deceleration over more atmosphere — lower peak G, longer heat pulse. Large γ (steep) is a short, violent brake. Too steep and structural G limits fail; too shallow and you may skip or overshoot the target corridor.",
+  },
+  {
+    id: "beta",
+    term: "Ballistic coefficient (β)",
+    short: "β = m / (Cd · A) — how hard the vehicle is to slow with drag.",
+    body: "High β vehicles (heavy, small area, low Cd) reach denser air before slowing, raising peak heating and often peak G. Enlarging the heat shield lowers β. Units here are kg/m².",
+  },
+  {
+    id: "gload",
+    term: "Deceleration (G-load)",
+    short: "Drag acceleration expressed in multiples of Earth gravity.",
+    body: "Peak G is a structural and crew/payload limit. This tool flags configurations above ~12 G as FAIL for the parametric study. Opening-shock G at parachute deploy is a separate spike that can snap lines. Because Sea Turtle is ballistic (no lift), many LEO-like cases fail the screen — use FAIL as a prompt to compare trades, not as a flight prediction.",
+  },
+  {
+    id: "heatflux",
+    term: "Stagnation heat flux",
+    short: "Estimated convective heating at the nose/shield stagnation point.",
+    body: "Sea Turtle uses a Sutton–Graves-style estimate: q̇ ∝ √(ρ / R_n) · V³. It is a first-order trend tool, not a TPS sizing code. Peak flux (W/cm²) drives material and thickness trades with density.",
+  },
+  {
+    id: "tps",
+    term: "Thermal protection system (TPS)",
+    short: "The heat shield mass is area × thickness × density.",
+    body: "TPS mass is added to payload mass before β is computed. Thicker or denser shields protect more but raise mass — which can raise β unless area grows too. Real TPS also ablates and conducts; this model only accounts for inert mass.",
+  },
+  {
+    id: "atmosphere",
+    term: "Exponential atmosphere",
+    short: "ρ = ρ₀ · exp(−h / H) below the Kármán line.",
+    body: "With ρ₀ = 1.225 kg/m³ and scale height H ≈ 8.5 km, density grows rapidly as altitude falls. That is why most deceleration and heating concentrate in a relatively thin band of the lower atmosphere.",
+  },
+  {
+    id: "drag",
+    term: "2-DOF point-mass drag model",
+    short: "Planar motion with drag opposing velocity; gravity on the vertical axis.",
+    body: "The integrator steps altitude and velocity components with a variable time step (coarse in space, fine in atmosphere). Lift, Coriolis detail, and shape-dependent aerodynamics are omitted — transparency over fidelity.",
+  },
+  {
+    id: "chute",
+    term: "Parachute deploy & opening shock",
+    short: "Below deploy altitude, Cd and area switch to the chute.",
+    body: "Opening shock estimates dynamic pressure × chute area × Cd × a shock factor, divided by weight. Deploy higher to open in thinner air; a smaller chute reduces shock but raises terminal speed.",
+  },
+  {
+    id: "deorbit",
+    term: "Deorbit burn longitude",
+    short: "Where to start the entry so the ground track reaches the target.",
+    body: "An iterative targeting loop estimates the Earth-relative longitude of the deorbit burn given the simulated downrange. It is a conceptual targeting aid, not a flight-dynamics product.",
+  },
+]);
+
+/** Field-level help keyed by input element id. */
+export const FIELD_HELP = Object.freeze({
+  payloadMassKg: "Dry payload mass before adding heat-shield TPS mass.",
+  startAltKm: "Initial geodetic altitude. Typical LEO returns start near 100–400 km.",
+  startVelMps: "Inertial-ish entry speed magnitude. LEO ≈ 7.5–7.8 km/s; faster ⇒ much more heat.",
+  entryAngleDeg: "Flight-path angle below local horizontal. ~3–5° is a common capsule corridor start.",
+  targetLat: "Landing-site latitude used for ground-track / deorbit longitude targeting.",
+  targetLon: "Landing-site longitude (deg). Positive east.",
+  shieldCd: "Heat-shield drag coefficient while ballistic (pre-chute).",
+  chuteCd: "Parachute drag coefficient after deploy.",
+  chuteDeployAltM: "Altitude where the model switches from shield to chute aerodynamics.",
+  tpsDensity: "Areal TPS density used only to compute shield mass (kg/m³).",
+  tpsThickness: "Uniform shield thickness for mass estimate (m).",
+  shockFactorX: "Multiplier on ideal chute load to approximate inflation dynamics.",
+  testShieldDiams: "Comma-separated shield diameters (m) for the parametric sweep.",
+  testChuteDiams: "Comma-separated chute diameters (m) for the parametric sweep.",
+});
+
+export const MODEL_ASSUMPTIONS = Object.freeze([
+  "Point-mass, planar 2-DOF; no lift, bank, or guidance closed loop.",
+  "Exponential atmosphere below 100 km; near-vacuum above.",
+  "Constant Cd per phase (shield vs chute); no Mach/Re tables.",
+  "Sutton–Graves-style stagnation flux — trend only, not certified heating.",
+  "TPS contributes mass only; no ablation, conduction, or bond-line temperature.",
+  "Earth rotation appears only in a simple longitude correction.",
+  "PASS/FAIL uses a 12 G structural/crew proxy for peak G and chute shock.",
+]);
+
+/**
+ * Build a short plain-language story of the latest study for learners.
+ * @param {object} study
+ * @param {object} cfg
+ */
+export function buildNarrative(study, cfg) {
+  if (!study?.rows?.length) {
+    return {
+      headline: "Run a simulation to see what the physics is doing.",
+      paragraphs: [],
+      takeaways: [],
+    };
+  }
+
+  const pass = study.rows.filter((r) => r.status === "PASS");
+  const fail = study.rows.filter((r) => r.status === "FAIL");
+  const hottest = study.rows.reduce((a, b) => (b.q > a.q ? b : a), study.rows[0]);
+  const hardest = study.rows.reduce((a, b) => (b.g > a.g ? b : a), study.rows[0]);
+  const softest = study.rows.reduce((a, b) => (b.g < a.g ? b : a), study.rows[0]);
+
+  const paragraphs = [
+    `You entered from ${cfg.startAltKm} km at ${cfg.startVelMps} m/s with γ = ${cfg.entryAngleDeg}°. Below the Kármán line (~100 km), exponential atmosphere density rises fast, so drag — and heating — concentrate in a relatively thin band.`,
+    `Across ${study.rows.length} shield×chute pairs, ballistic coefficient β ranged from ${Math.min(...study.rows.map((r) => r.beta)).toFixed(0)} to ${Math.max(...study.rows.map((r) => r.beta)).toFixed(0)} kg/m². Larger shields lower β. In this no-lift ballistic model, peak G often stays high even as β falls — real capsules use lift and guidance to stretch the pulse.`,
+    `Hardest peak deceleration: ${hardest.g.toFixed(1)} G (${hardest.shield.toFixed(1)} m shield). Softest in this sweep: ${softest.g.toFixed(1)} G. Hottest stagnation flux: ${hottest.q.toFixed(1)} W/cm² on the ${hottest.shield.toFixed(1)} m shield.`,
+  ];
+
+  if (hardest.altMaxG != null) {
+    paragraphs.push(
+      `Peak G for the hardest case sits near ~${hardest.altMaxG.toFixed(0)} km altitude — where density and leftover speed still combine before the vehicle has fully bled energy.`,
+    );
+  }
+
+  const corridorNote = study.steepestFeasible
+    ? `Steepest angle under the ≈11.9 G search: ${study.steepestAngle.toFixed(2)}°.`
+    : `Even a very shallow γ (~0.5°) still peaks near ${Number(study.shallowG).toFixed(1)} G in this ballistic model — the 12 G PASS flag is a teaching screen, not a claim that lift-assisted entry is impossible.`;
+
+  const takeaways = [
+    `${pass.length} of ${study.rows.length} configurations PASS the 12 G peak / chute-shock screen; ${fail.length} FAIL.`,
+    corridorNote,
+    `Suggested deorbit-burn longitude for Lat ${cfg.targetLat.toFixed(2)}° / Lon ${cfg.targetLon.toFixed(2)}°: ${study.deorbitLon.toFixed(2)}°.`,
+    `Learning tip: change one knob (γ, mass, velocity, or shield size), re-run, and compare Heat and Max G — relative trades matter more than the absolute PASS flag here.`,
+  ];
+
+  let headline;
+  if (fail.length === 0) {
+    headline = "All tested configurations stay within the 12 G proxy limits.";
+  } else if (pass.length === 0) {
+    headline =
+      "All cases exceed the 12 G teaching screen — use relative trades (Heat, β, shock) to learn the physics.";
+  } else {
+    headline = "Mixed results: some shield/chute pairs survive the G screen, others do not.";
+  }
+
+  return { headline, paragraphs, takeaways };
+}
+
+/** Self-study module outlines shown in the Learn section. */
+export const STUDY_MODULES = Object.freeze([
+  {
+    title: "Module 1 — Energy and the atmosphere",
+    steps: [
+      "Run the LEO capsule preset. Note space-phase vs air-phase times.",
+      "Open the glossary entry for exponential atmosphere.",
+      "Ask: why do both G and heat flux stay near zero until well below 100 km?",
+    ],
+  },
+  {
+    title: "Module 2 — Ballistic coefficient trades",
+    steps: [
+      "Compare the default table rows: how does β fall as shield diameter rises?",
+      "Load Heavy probe. What happens to Max G and Heat at the same γ?",
+      "In Research mode, add a 2.4 m shield diameter to the sweep.",
+    ],
+  },
+  {
+    title: "Module 3 — Entry angle corridor",
+    steps: [
+      "Run Steep ballistic entry. Compare Max G and Heat to the LEO default.",
+      "Read the engineer notes: this no-lift model may report no feasible 12 G corridor.",
+      "Relate γ to pulse shape: steeper still tends to be sharper; real capsules add lift to stretch the pulse.",
+    ],
+  },
+  {
+    title: "Module 4 — Heating scales with V³",
+    steps: [
+      "Run Higher-energy return. Compare peak heat flux to the LEO case.",
+      "Read the Sutton–Graves glossary note.",
+      "Export CSV (Research mode) and plot Heat vs shield diameter offline.",
+    ],
+  },
+]);

--- a/web/js/sim.js
+++ b/web/js/sim.js
@@ -1,11 +1,20 @@
 /*
  * STRIDE — Re-Entry Predictor (aka Sea Turtle)
- * Client-side port of the reference Python trajectory simulation.
+ * Client-side no-lift ballistic entry model.
  *
- * Physics-informed, first-order model. Same governing equations as the
- * Python reference: 2-DOF point-mass entry with exponential atmosphere,
- * ballistic-coefficient drag, variable time step, and a Sutton-Graves style
- * stagnation-point heat-flux estimate.
+ * Planar 2-DOF point-mass equations in (h, V, γ) with:
+ *   - continuous exponential atmosphere
+ *   - inverse-square gravity
+ *   - drag only (L/D = 0) — classic ballistic entry
+ *   - Sutton–Graves-style stagnation heat-flux estimate
+ *   - parachute phase via Cd/A switch + opening-shock proxy
+ *
+ * Flight-path angle γ is measured from local horizontal and is negative
+ * during descent (aerospace convention). The UI still enters a positive
+ * "entry angle" in degrees below the horizon.
+ *
+ * Peak G is recorded during the heat-shield (ballistic) phase only; chute
+ * opening load is reported separately as Shock G.
  *
  * Nothing here talks to a server. All computation happens in the visitor's
  * browser, which is why there is no server-side attack surface.
@@ -13,12 +22,18 @@
 
 export const CONSTANTS = Object.freeze({
   R_EARTH: 6371000.0,
-  G_ACCEL: 9.81,
+  G0: 9.81,
   RHO_0: 1.225,
   H_SCALE: 8500.0,
   KARMAN_LINE: 100000.0,
   K_SG: 1.7415e-4,
   ROT_SPEED: 7.2921e-5,
+  /** Approximate peak-G factor from Allen–Eggers: V² sin|γ| / (2 e H) */
+  ALLEN_EGGERS_E: Math.E,
+  /** Abort if the vehicle lofts above this altitude (skip / escape). */
+  SKIP_ABORT_ALT_M: 2_000_000,
+  /** Soft wall-clock for a single integration (seconds of simulated time). */
+  MAX_SIM_TIME_S: 20_000,
 });
 
 // Defaults mirror the Python "USER CONFIGURATION PANEL".
@@ -45,128 +60,239 @@ const rad2deg = (r) => (r * 180.0) / Math.PI;
 
 // Safety guard: prevents a pathological input set from freezing the browser
 // tab with an unbounded integration loop.
-const MAX_STEPS = 5_000_000;
+const MAX_STEPS = 2_000_000;
+
+function density(h) {
+  // Continuous exponential model (tiny but non-zero above the Kármán line).
+  return CONSTANTS.RHO_0 * Math.exp(-Math.max(h, 0) / CONSTANTS.H_SCALE);
+}
+
+function gravity(h) {
+  const r = CONSTANTS.R_EARTH + Math.max(h, 0);
+  return CONSTANTS.G0 * (CONSTANTS.R_EARTH / r) ** 2;
+}
+
+/**
+ * Allen–Eggers closed-form peak deceleration (G) for exponential-atmosphere
+ * ballistic entry at constant γ. Real no-lift trajectories steepen as they
+ * slow, so the numerical peak can exceed this estimate — especially at
+ * shallow entry angles.
+ */
+export function allenEggersPeakG(velMps, entryAngleDeg) {
+  const gamma = deg2rad(Math.abs(entryAngleDeg));
+  const aMax =
+    (velMps * velMps * Math.sin(gamma)) /
+    (2 * CONSTANTS.ALLEN_EGGERS_E * CONSTANTS.H_SCALE);
+  return aMax / CONSTANTS.G0;
+}
+
+function pickDt(h, v, rho) {
+  // Coarse in vacuum / loft, finer where drag rises, finest near chute.
+  if (h > CONSTANTS.KARMAN_LINE + 50000) return 2.0;
+  if (h > CONSTANTS.KARMAN_LINE) return 0.5;
+  if (h > 40000) return 0.1;
+  if (h > 15000) return 0.05;
+  if (rho * v > 200) return 0.02;
+  return 0.05;
+}
+
+/**
+ * Right-hand side of the no-lift planar entry ODEs.
+ * State: altitude h [m], speed V [m/s], flight-path γ [rad] (neg. = descent).
+ *
+ *   dh/dt     = V sin γ
+ *   dV/dt     = −D/m − g sin γ
+ *   dγ/dt     = cos γ · (V/r − g/V)     (L = 0)
+ */
+function derivs(h, v, gamma, mass, cd, area) {
+  const C = CONSTANTS;
+  const r = C.R_EARTH + h;
+  const g = gravity(h);
+  const rho = density(h);
+  const safeV = Math.max(v, 1e-9);
+  const dragA = (0.5 * rho * safeV * safeV * cd * area) / mass;
+
+  return {
+    dh: safeV * Math.sin(gamma),
+    dV: -dragA - g * Math.sin(gamma),
+    dGamma: Math.cos(gamma) * (safeV / r - g / safeV),
+    dragA,
+    rho,
+    g,
+  };
+}
 
 /**
  * Run one entry simulation for a given heat-shield diameter, chute diameter,
- * and flight-path angle. Returns summary metrics plus down-sampled logs.
+ * and flight-path angle (positive degrees below horizon). Returns summary
+ * metrics plus down-sampled logs.
  */
-export function runMasterSim(cfg, sDia, pDia, gammaIn) {
+export function runMasterSim(cfg, sDia, pDia, gammaInDeg) {
   const C = CONSTANTS;
   const sArea = Math.PI * (sDia / 2) ** 2;
+  const pArea = Math.PI * (pDia / 2) ** 2;
   const shieldMass = sArea * cfg.tpsThickness * cfg.tpsDensity;
   const totalMass = cfg.payloadMassKg + shieldMass + 5.0;
   const beta = totalMass / (cfg.shieldCd * sArea);
 
   let h = cfg.startAltKm * 1000.0;
-  const gamma = deg2rad(gammaIn);
-  let vx = cfg.startVelMps * Math.cos(gamma);
-  let vz = cfg.startVelMps * Math.sin(gamma);
+  let v = cfg.startVelMps;
+  // UI entry angle is below-horizon positive → γ negative for descent.
+  let gamma = -deg2rad(Math.abs(gammaInDeg));
 
   let t = 0,
     tK = 0,
-    tC = 0,
     maxG = 0,
     maxQ = 0,
+    maxQdyn = 0,
     shockG = 0,
     altMaxG = 0,
     altMaxQ = 0,
-    kReached = false;
+    rangeM = 0,
+    kReached = false,
+    chuteDeployed = false,
+    outcome = "integrating";
 
   const altLog = [];
   const gLog = [];
   const qLog = [];
-  let lonRel = 0.0;
   let stepCount = 0;
 
-  while (h > 0 && stepCount < MAX_STEPS) {
-    const dt = h < C.KARMAN_LINE + 5000 ? 0.05 : 2.0;
-    const rho = h < C.KARMAN_LINE ? C.RHO_0 * Math.exp(-h / C.H_SCALE) : 1e-15;
-    const vMag = Math.sqrt(vx * vx + vz * vz);
+  while (stepCount < MAX_STEPS) {
+    if (h <= 0) {
+      outcome = "landed";
+      h = 0;
+      break;
+    }
+    if (v <= 0.2) {
+      outcome = h < 1000 ? "landed" : "stalled";
+      break;
+    }
+    if (t > C.MAX_SIM_TIME_S) {
+      outcome = "timeout";
+      break;
+    }
+    if (h > C.SKIP_ABORT_ALT_M) {
+      outcome = "skipped";
+      break;
+    }
+
+    const rho = density(h);
+    const dt = pickDt(h, v, rho);
 
     if (h <= C.KARMAN_LINE && !kReached) {
       tK = t;
       kReached = true;
     }
 
-    let area, cd;
-    if (h <= cfg.chuteDeployAltM) {
-      const pArea = Math.PI * (pDia / 2) ** 2;
-      if (shockG === 0) {
-        const qDyn = 0.5 * rho * vMag * vMag;
-        shockG =
-          (qDyn * pArea * cfg.chuteCd * cfg.shockFactorX) /
-          (totalMass * C.G_ACCEL);
-      }
-      area = pArea;
-      cd = cfg.chuteCd;
-      tC += dt;
-    } else {
-      area = sArea;
-      cd = cfg.shieldCd;
+    // Capture opening shock on the ballistic state *before* chute aero is
+    // applied, so RK2 midpoints cannot bleed speed and under-report shock.
+    if (!chuteDeployed && h <= cfg.chuteDeployAltM) {
+      const qDyn = 0.5 * rho * v * v;
+      shockG =
+        (qDyn * pArea * cfg.chuteCd * cfg.shockFactorX) /
+        (totalMass * C.G0);
+      chuteDeployed = true;
     }
 
-    const dragA = (0.5 * rho * vMag * vMag * cd * area) / totalMass;
-    // Guard against divide-by-zero if velocity collapses to exactly 0.
-    const safeVMag = vMag === 0 ? 1e-12 : vMag;
-    vx += -(dragA * (vx / safeVMag)) * dt;
-    vz += (-(dragA * (vz / safeVMag)) + C.G_ACCEL) * dt;
-    h -= vz * dt;
+    const area = chuteDeployed ? pArea : sArea;
+    const cd = chuteDeployed ? cfg.chuteCd : cfg.shieldCd;
 
-    const curG = dragA / C.G_ACCEL;
-    if (curG > maxG) {
-      maxG = curG;
-      altMaxG = h / 1000;
+    // Midpoint (RK2) integration of the no-lift ODEs.
+    const k1 = derivs(h, v, gamma, totalMass, cd, area);
+    const hMid = h + 0.5 * dt * k1.dh;
+    const vMid = Math.max(v + 0.5 * dt * k1.dV, 0);
+    const gMid = gamma + 0.5 * dt * k1.dGamma;
+    // Keep aero mode fixed across the step once the chute decision is made.
+    const k2 = derivs(hMid, vMid, gMid, totalMass, cd, area);
+
+    // Ballistic peak G from shield aero only (never from chute Cd/A).
+    const shieldDragA =
+      (0.5 * rho * Math.max(v, 1e-9) ** 2 * cfg.shieldCd * sArea) / totalMass;
+    const ballisticG = shieldDragA / C.G0;
+    if (!chuteDeployed && ballisticG > maxG) {
+      maxG = ballisticG;
+      altMaxG = Math.max(h, 0) / 1000;
     }
+
+    h += dt * k2.dh;
+    v = Math.max(v + dt * k2.dV, 0);
+    gamma += dt * k2.dGamma;
+
+    const qDyn = 0.5 * k2.rho * v * v;
+    if (qDyn > maxQdyn) maxQdyn = qDyn;
 
     let qDot = 0;
-    if (h < C.KARMAN_LINE) {
-      qDot = (C.K_SG * Math.sqrt(rho / (sDia / 2)) * vMag ** 3) / 10000.0;
+    if (h < C.KARMAN_LINE && h > 0) {
+      qDot =
+        (C.K_SG * Math.sqrt(Math.max(k2.rho, 0) / (sDia / 2)) * v ** 3) /
+        10000.0;
       if (qDot > maxQ) {
         maxQ = qDot;
         altMaxQ = h / 1000;
       }
     }
 
+    // Ground-range increment (arc on spherical Earth).
+    const r = C.R_EARTH + Math.max(h, 0);
+    rangeM += ((v * Math.cos(gamma) * C.R_EARTH) / r) * dt;
+
     if (stepCount % 20 === 0) {
       altLog.push(h / 1000);
-      gLog.push(curG);
+      gLog.push(ballisticG);
       qLog.push(qDot);
     }
 
     t += dt;
     stepCount += 1;
-    lonRel += (vx * dt) / (C.R_EARTH * Math.cos(deg2rad(cfg.targetLat)));
-    if (vMag < 0.2) break;
   }
 
+  if (stepCount >= MAX_STEPS && outcome === "integrating") {
+    outcome = "timeout";
+  }
+
+  const latRad = deg2rad(cfg.targetLat);
+  const cosLat = Math.max(Math.abs(Math.cos(latRad)), 1e-6);
+  const lonRelDeg = rad2deg(rangeM / (C.R_EARTH * cosLat));
+  const earthRotateDeg = rad2deg(C.ROT_SPEED * t);
+
   return {
-    lon: rad2deg(lonRel) - rad2deg(C.ROT_SPEED * t),
+    lon: lonRelDeg - earthRotateDeg,
     beta,
     t1: tK,
-    t2: t - tK,
+    t2: kReached ? Math.max(t - tK, 0) : 0,
     g: maxG,
     q: maxQ,
     shock: shockG,
     altMaxG,
     altMaxQ,
+    maxQdyn,
+    rangeKm: rangeM / 1000,
+    allenEggersG: allenEggersPeakG(cfg.startVelMps, gammaInDeg),
+    outcome,
     alt: altLog,
     gArr: gLog,
     qArr: qLog,
-    timedOut: stepCount >= MAX_STEPS,
+    timedOut: outcome === "timeout",
   };
 }
 
-/** Iterative deorbit-burn longitude targeting (mirrors the Python solver). */
+function referenceShieldChute(cfg) {
+  const shield =
+    cfg.testShieldDiams[
+      Math.min(1, Math.max(0, cfg.testShieldDiams.length - 1))
+    ];
+  const chute = cfg.testChuteDiams[0];
+  return { shield, chute };
+}
+
+/** Iterative deorbit-burn longitude targeting. */
 export function solveDeorbitLongitude(cfg) {
+  const { shield, chute } = referenceShieldChute(cfg);
   let eLon = cfg.targetLon - 22.0;
   for (let i = 0; i < 5; i++) {
-    const s = runMasterSim(
-      cfg,
-      cfg.testShieldDiams[1],
-      cfg.testChuteDiams[0],
-      cfg.entryAngleDeg,
-    );
+    const s = runMasterSim(cfg, shield, chute, cfg.entryAngleDeg);
+    if (s.outcome !== "landed") break;
     eLon += cfg.targetLon - (eLon + s.lon);
   }
   return eLon;
@@ -174,23 +300,25 @@ export function solveDeorbitLongitude(cfg) {
 
 /**
  * Binary search for the steepest survivable entry angle (< 11.9 G).
- * Returns { angle, feasible }. When the shallowest probe still exceeds the
- * G proxy (common for this no-lift ballistic model), feasible is false.
+ * Returns { angle, feasible, shallowG }.
  */
 export function solveSteepestAngle(cfg) {
-  const shield = cfg.testShieldDiams[Math.min(1, cfg.testShieldDiams.length - 1)];
-  const chute = cfg.testChuteDiams[0];
+  const { shield, chute } = referenceShieldChute(cfg);
   const shallow = runMasterSim(cfg, shield, chute, 0.5);
-  if (shallow.g >= 11.9) {
-    return { angle: 0.5, feasible: false, shallowG: shallow.g };
+  if (shallow.outcome !== "landed" || shallow.g >= 11.9) {
+    return {
+      angle: 0.5,
+      feasible: shallow.outcome === "landed" && shallow.g < 11.9,
+      shallowG: shallow.g,
+    };
   }
   let lo = 0.5,
-    hi = 10.0,
+    hi = 15.0,
     mid = (lo + hi) / 2;
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < 14; i++) {
     mid = (lo + hi) / 2;
     const res = runMasterSim(cfg, shield, chute, mid);
-    if (res.g < 11.9) lo = mid;
+    if (res.outcome === "landed" && res.g < 11.9) lo = mid;
     else hi = mid;
   }
   return { angle: mid, feasible: true, shallowG: shallow.g };
@@ -199,13 +327,21 @@ export function solveSteepestAngle(cfg) {
 /** Build the full parametric study across shield/chute diameters. */
 export function runStudy(cfg) {
   const rows = [];
-  const decelSeries = []; // for the first chute diameter, per shield
+  const decelSeries = [];
   const thermalSeries = [];
 
   for (const sd of cfg.testShieldDiams) {
     for (const pd of cfg.testChuteDiams) {
       const r = runMasterSim(cfg, sd, pd, cfg.entryAngleDeg);
-      const surv = r.g <= 12.0 && r.shock <= 12.0 ? "PASS" : "FAIL";
+      const landed = r.outcome === "landed";
+      const surv =
+        landed && r.g <= 12.0 && r.shock <= 12.0
+          ? "PASS"
+          : landed
+            ? "FAIL"
+            : r.outcome === "skipped"
+              ? "SKIP"
+              : "FAIL";
       rows.push({
         shield: sd,
         chute: pd,
@@ -217,6 +353,10 @@ export function runStudy(cfg) {
         q: r.q,
         altMaxG: r.altMaxG,
         altMaxQ: r.altMaxQ,
+        rangeKm: r.rangeKm,
+        maxQdyn: r.maxQdyn,
+        allenEggersG: r.allenEggersG,
+        outcome: r.outcome,
         status: surv,
       });
 
@@ -228,6 +368,7 @@ export function runStudy(cfg) {
   }
 
   const steepest = solveSteepestAngle(cfg);
+  const ae = allenEggersPeakG(cfg.startVelMps, cfg.entryAngleDeg);
   return {
     rows,
     decelSeries,
@@ -236,6 +377,7 @@ export function runStudy(cfg) {
     steepestAngle: steepest.angle,
     steepestFeasible: steepest.feasible,
     shallowG: steepest.shallowG,
+    allenEggersG: ae,
   };
 }
 

--- a/web/js/sim.js
+++ b/web/js/sim.js
@@ -69,6 +69,8 @@ export function runMasterSim(cfg, sDia, pDia, gammaIn) {
     maxG = 0,
     maxQ = 0,
     shockG = 0,
+    altMaxG = 0,
+    altMaxQ = 0,
     kReached = false;
 
   const altLog = [];
@@ -112,12 +114,18 @@ export function runMasterSim(cfg, sDia, pDia, gammaIn) {
     h -= vz * dt;
 
     const curG = dragA / C.G_ACCEL;
-    if (curG > maxG) maxG = curG;
+    if (curG > maxG) {
+      maxG = curG;
+      altMaxG = h / 1000;
+    }
 
     let qDot = 0;
     if (h < C.KARMAN_LINE) {
       qDot = (C.K_SG * Math.sqrt(rho / (sDia / 2)) * vMag ** 3) / 10000.0;
-      if (qDot > maxQ) maxQ = qDot;
+      if (qDot > maxQ) {
+        maxQ = qDot;
+        altMaxQ = h / 1000;
+      }
     }
 
     if (stepCount % 20 === 0) {
@@ -140,6 +148,8 @@ export function runMasterSim(cfg, sDia, pDia, gammaIn) {
     g: maxG,
     q: maxQ,
     shock: shockG,
+    altMaxG,
+    altMaxQ,
     alt: altLog,
     gArr: gLog,
     qArr: qLog,
@@ -162,23 +172,28 @@ export function solveDeorbitLongitude(cfg) {
   return eLon;
 }
 
-/** Binary search for the steepest survivable entry angle (< 11.9 G). */
+/**
+ * Binary search for the steepest survivable entry angle (< 11.9 G).
+ * Returns { angle, feasible }. When the shallowest probe still exceeds the
+ * G proxy (common for this no-lift ballistic model), feasible is false.
+ */
 export function solveSteepestAngle(cfg) {
+  const shield = cfg.testShieldDiams[Math.min(1, cfg.testShieldDiams.length - 1)];
+  const chute = cfg.testChuteDiams[0];
+  const shallow = runMasterSim(cfg, shield, chute, 0.5);
+  if (shallow.g >= 11.9) {
+    return { angle: 0.5, feasible: false, shallowG: shallow.g };
+  }
   let lo = 0.5,
     hi = 10.0,
     mid = (lo + hi) / 2;
   for (let i = 0; i < 12; i++) {
     mid = (lo + hi) / 2;
-    const res = runMasterSim(
-      cfg,
-      cfg.testShieldDiams[1],
-      cfg.testChuteDiams[0],
-      mid,
-    );
+    const res = runMasterSim(cfg, shield, chute, mid);
     if (res.g < 11.9) lo = mid;
     else hi = mid;
   }
-  return mid;
+  return { angle: mid, feasible: true, shallowG: shallow.g };
 }
 
 /** Build the full parametric study across shield/chute diameters. */
@@ -200,6 +215,8 @@ export function runStudy(cfg) {
         g: r.g,
         shock: r.shock,
         q: r.q,
+        altMaxG: r.altMaxG,
+        altMaxQ: r.altMaxQ,
         status: surv,
       });
 
@@ -210,12 +227,15 @@ export function runStudy(cfg) {
     }
   }
 
+  const steepest = solveSteepestAngle(cfg);
   return {
     rows,
     decelSeries,
     thermalSeries,
     deorbitLon: solveDeorbitLongitude(cfg),
-    steepestAngle: solveSteepestAngle(cfg),
+    steepestAngle: steepest.angle,
+    steepestFeasible: steepest.feasible,
+    shallowG: steepest.shallowG,
   };
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -10,6 +10,7 @@
   --accent-2: #60a5fa;
   --pass: #34d399;
   --fail: #f87171;
+  --warning: #fbbf24;
   --radius: 14px;
   --shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
   --maxw: 1160px;
@@ -354,6 +355,10 @@ legend {
 }
 .results td.fail {
   color: var(--fail);
+  font-weight: 700;
+}
+.results td.skip {
+  color: var(--warning, #fbbf24);
   font-weight: 700;
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -13,6 +13,8 @@
   --radius: 14px;
   --shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
   --maxw: 1160px;
+  --font-display: "Segoe UI", ui-sans-serif, system-ui, sans-serif;
+  --font-body: "Segoe UI", ui-sans-serif, system-ui, sans-serif;
 }
 
 * {
@@ -30,9 +32,13 @@ body {
     radial-gradient(900px 500px at 0% 0%, rgba(94, 234, 212, 0.1), transparent 55%),
     var(--bg);
   color: var(--ink);
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--font-body);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+}
+
+body[data-mode="learn"] .research-only {
+  display: none !important;
 }
 
 .wrap {
@@ -377,6 +383,241 @@ legend {
   font-size: 0.92rem;
 }
 
+/* TOOL INTRO + MODE */
+.tool-intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.tool-intro .section-sub {
+  margin-bottom: 0;
+}
+.mode-switch {
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel-2);
+  flex-shrink: 0;
+}
+.mode-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mode-btn.is-active {
+  background: linear-gradient(120deg, rgba(94, 234, 212, 0.2), rgba(96, 165, 250, 0.22));
+  color: var(--ink);
+  box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.35);
+}
+
+/* PRESETS */
+.preset-block {
+  margin: 28px 0 22px;
+}
+.preset-heading {
+  margin: 0 0 4px;
+  font-size: 1.05rem;
+}
+.presets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+.preset-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  text-align: left;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 0.2s ease, transform 0.15s ease, background 0.2s ease;
+}
+.preset-card:hover {
+  border-color: var(--accent-2);
+  transform: translateY(-2px);
+}
+.preset-card.is-active {
+  border-color: var(--accent);
+  background: linear-gradient(160deg, rgba(94, 234, 212, 0.1), var(--panel));
+}
+.preset-level {
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.preset-name {
+  font-weight: 700;
+  font-size: 0.98rem;
+}
+.preset-blurb {
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.preset-teach {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 14px 0 0;
+  max-width: 80ch;
+  min-height: 1.4em;
+}
+
+/* LEARN SECTION */
+.learn-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+.learn-panel .howto {
+  margin: 0 0 12px;
+  padding-left: 20px;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+.learn-panel .howto li {
+  margin-bottom: 8px;
+}
+.learn-panel .howto strong {
+  color: var(--ink);
+}
+.modules {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.module h4 {
+  margin: 0 0 6px;
+  font-size: 0.95rem;
+  color: var(--accent);
+}
+.module ol {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+.module li {
+  margin-bottom: 4px;
+}
+
+.glossary-panel {
+  margin-bottom: 18px;
+}
+.glossary-head .panel-note {
+  margin-bottom: 12px;
+}
+.glossary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+}
+.glossary-item {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel-2);
+  padding: 0 12px;
+}
+.glossary-item summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.glossary-item summary::-webkit-details-marker {
+  display: none;
+}
+.glossary-item[open] {
+  border-color: rgba(94, 234, 212, 0.35);
+}
+.glossary-term {
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+.glossary-short {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+.glossary-body {
+  color: var(--muted);
+  font-size: 0.86rem;
+  margin: 0 0 12px;
+  padding-top: 2px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.assumptions {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  padding: 14px 18px;
+}
+.assumptions summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ink);
+}
+.assumptions .check {
+  margin-top: 14px;
+}
+
+/* FIELD HELP + NARRATIVE */
+.field-help {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--muted);
+  opacity: 0.9;
+  line-height: 1.35;
+  margin: -2px 0 2px;
+}
+.narrative {
+  margin-bottom: 22px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.narrative-headline {
+  color: var(--accent);
+  font-weight: 600;
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+.narrative-body p {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0 0 10px;
+}
+.narrative-takeaways {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+.narrative-takeaways li {
+  color: var(--ink);
+  font-size: 0.88rem;
+  margin-bottom: 6px;
+}
+
 /* PHILOSOPHY */
 .two-col {
   display: grid;
@@ -428,11 +669,15 @@ legend {
   .charts {
     grid-template-columns: 1fr;
   }
-  .two-col {
+  .two-col,
+  .learn-grid {
     grid-template-columns: 1fr;
     gap: 28px;
   }
   .nav {
     display: none;
+  }
+  .tool-intro {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a **Learn** path for Sea Turtle: mission presets, concept glossary, self-study modules, inline field help, model-assumptions panel, and a plain-language “what just happened” narrative after each run.
- Add a **Research** mode: custom shield/chute diameter sweeps, targeting/shock knobs, and CSV/JSON export.
- Replace the old flat-Earth Cartesian integrator with a proper **no-lift ballistic** model in `(h, V, γ)`: exponential atmosphere, inverse-square gravity, RK2 stepping, shield-only peak G, chute opening shock, Allen–Eggers teaching check, and `SKIP` for lofted trajectories.

## Physics notes
- Default LEO case now peaks near ~11 G (Allen–Eggers teaching check ≈ 8.4 G); the previous integrator falsely reported ~39 G.
- Peak G is largely set by `V` and `γ`; shield diameter mainly moves heat flux and chute shock.
- Super-circular / too-shallow starts can loft and report `SKIP`.

## Testing
- Node smoke tests of `sim.js` + `learn.js` (default study, presets, shock∝chute area, Allen–Eggers check)
- Default study: mixed PASS/FAIL with steepest survivable γ ≈ 4.2°
- Study runtime ~75 ms in-process
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44aa8535-db38-488a-af9a-e2fa7c737d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44aa8535-db38-488a-af9a-e2fa7c737d97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

